### PR TITLE
Add Multi-Modality PerceiverIO

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,19 +23,22 @@ model = Perceiver(
     input_axis = 2,              # number of axis for input data (2 for images, 3 for video)
     num_freq_bands = 6,          # number of freq bands, with original value (2 * K + 1)
     max_freq = 10.,              # maximum frequency, hyperparameter depending on how fine the data is
-    depth = 6,                   # depth of net
+    freq_base = 2,
+    depth = 6,                   # depth of net. The shape of the final attention mechanism will be:
+                                 #   depth * (cross attention -> self_per_cross_attn * self attention)
     num_latents = 256,           # number of latents, or induced set points, or centroids. different papers giving it different names
     latent_dim = 512,            # latent dimension
     cross_heads = 1,             # number of heads for cross attention. paper said 1
     latent_heads = 8,            # number of heads for latent self attention, 8
-    cross_dim_head = 64,
-    latent_dim_head = 64,
+    cross_dim_head = 64,         # number of dimensions per cross attention head
+    latent_dim_head = 64,        # number of dimensions per latent self attention head
     num_classes = 1000,          # output number of classes
     attn_dropout = 0.,
     ff_dropout = 0.,
     weight_tie_layers = False,   # whether to weight tie layers (optional, as indicated in the diagram)
     fourier_encode_data = True,  # whether to auto-fourier encode the data, using the input_axis given. defaults to True, but can be turned off if you are fourier encoding the data yourself
-    self_per_cross_attn = 2      # number of self attention blocks per cross attention
+    self_per_cross_attn = 2,     # number of self attention blocks per cross attention
+    self_attn_rel_pos = True
 )
 
 img = torch.randn(1, 224, 224, 3) # 1 imagenet image, pixelized

--- a/perceiver_pytorch/experimental.py
+++ b/perceiver_pytorch/experimental.py
@@ -4,47 +4,52 @@ import torch.nn.functional as F
 
 from einops import rearrange, repeat
 
-from perceiver_pytorch.perceiver_pytorch import exists, default, cache_fn, fourier_encode, PreNorm, FeedForward, Attention
+from perceiver_pytorch.perceiver_pytorch import (
+    exists,
+    default,
+    cache_fn,
+    fourier_encode,
+    PreNorm,
+    FeedForward,
+    Attention,
+)
 
 # linear attention
 
+
 class LinearAttention(nn.Module):
-    def __init__(
-        self,
-        dim,
-        *,
-        heads = 4,
-        dim_head = 64,
-        dropout = 0.
-    ):
+    def __init__(self, dim, *, heads=4, dim_head=64, dropout=0.0):
         super().__init__()
         inner_dim = heads * dim_head
         self.heads = heads
         self.scale = dim_head ** -0.5
 
-        self.to_qkv = nn.Linear(dim, inner_dim * 3, bias = False)
+        self.to_qkv = nn.Linear(dim, inner_dim * 3, bias=False)
         self.to_out = nn.Sequential(
-            nn.Linear(inner_dim, dim),
-            nn.Dropout(dropout)
+            nn.Linear(inner_dim, dim), nn.Dropout(dropout)
         )
 
-    def forward(self, x, mask = None):
+    def forward(self, x, mask=None):
         h = self.heads
-        q, k, v = self.to_qkv(x).chunk(3, dim = -1)
-        q, k, v = map(lambda t: rearrange(t, 'b n (h d) -> (b h) n d', h = h), (q, k, v))
+        q, k, v = self.to_qkv(x).chunk(3, dim=-1)
+        q, k, v = map(
+            lambda t: rearrange(t, "b n (h d) -> (b h) n d", h=h), (q, k, v)
+        )
 
         q *= self.scale
-        q, k = q.softmax(dim = -1), k.softmax(dim = -2)
+        q, k = q.softmax(dim=-1), k.softmax(dim=-2)
 
         if exists(mask):
-            k.masked_fill_(mask, 0.)
+            k.masked_fill_(mask, 0.0)
 
-        context = einsum('b n d, b n e -> b d e', q, k)
-        out = einsum('b d e, b n d -> b n e', context, v)
-        out = rearrange(out, ' (b h) n d -> b n (h d)', h = h)
+        context = einsum("b n d, b n e -> b d e", q, k)
+        out = einsum("b d e, b n d -> b n e", context, v)
+        out = rearrange(out, " (b h) n d -> b n (h d)", h=h)
         return self.to_out(out)
 
+
 # main class
+
 
 class Perceiver(nn.Module):
     def __init__(
@@ -53,19 +58,19 @@ class Perceiver(nn.Module):
         num_freq_bands,
         depth,
         max_freq,
-        freq_base = 2,
-        input_channels = 3,
-        input_axis = 2,
-        num_latents = 512,
-        latent_dim = 512,
-        cross_heads = 1,
-        latent_heads = 8,
-        cross_dim_head = 64,
-        latent_dim_head = 64,
-        num_classes = 1000,
-        attn_dropout = 0.,
-        ff_dropout = 0.,
-        weight_tie_layers = False
+        freq_base=2,
+        input_channels=3,
+        input_axis=2,
+        num_latents=512,
+        latent_dim=512,
+        cross_heads=1,
+        latent_heads=8,
+        cross_dim_head=64,
+        latent_dim_head=64,
+        num_classes=1000,
+        attn_dropout=0.0,
+        ff_dropout=0.0,
+        weight_tie_layers=False
     ):
         super().__init__()
         self.input_axis = input_axis
@@ -79,72 +84,149 @@ class Perceiver(nn.Module):
 
         self.data_proj = nn.Linear(input_dim, input_dim)
 
-        get_cross_attn = lambda: PreNorm(latent_dim, Attention(latent_dim, input_dim, heads = cross_heads, dim_head = cross_dim_head, dropout = attn_dropout), context_dim = input_dim)
-        get_cross_ff = lambda: PreNorm(latent_dim, FeedForward(latent_dim, dropout = ff_dropout))
+        get_cross_attn = lambda: PreNorm(
+            latent_dim,
+            Attention(
+                latent_dim,
+                input_dim,
+                heads=cross_heads,
+                dim_head=cross_dim_head,
+                dropout=attn_dropout,
+            ),
+            context_dim=input_dim,
+        )
+        get_cross_ff = lambda: PreNorm(
+            latent_dim, FeedForward(latent_dim, dropout=ff_dropout)
+        )
 
-        get_input_attn = lambda: PreNorm(input_dim, LinearAttention(input_dim, dropout = attn_dropout))
-        get_rev_cross_attn = lambda: PreNorm(input_dim, Attention(input_dim, latent_dim, heads = cross_heads, dim_head = cross_dim_head, dropout = attn_dropout), context_dim = latent_dim)
-        get_rev_cross_ff = lambda: PreNorm(input_dim, FeedForward(input_dim, dropout = ff_dropout))
+        get_input_attn = lambda: PreNorm(
+            input_dim, LinearAttention(input_dim, dropout=attn_dropout)
+        )
+        get_rev_cross_attn = lambda: PreNorm(
+            input_dim,
+            Attention(
+                input_dim,
+                latent_dim,
+                heads=cross_heads,
+                dim_head=cross_dim_head,
+                dropout=attn_dropout,
+            ),
+            context_dim=latent_dim,
+        )
+        get_rev_cross_ff = lambda: PreNorm(
+            input_dim, FeedForward(input_dim, dropout=ff_dropout)
+        )
 
-        get_latent_attn = lambda: PreNorm(latent_dim, Attention(latent_dim, heads = latent_heads, dim_head = latent_dim_head, dropout = attn_dropout))
-        get_latent_ff = lambda: PreNorm(latent_dim, FeedForward(latent_dim, dropout = ff_dropout))
+        get_latent_attn = lambda: PreNorm(
+            latent_dim,
+            Attention(
+                latent_dim,
+                heads=latent_heads,
+                dim_head=latent_dim_head,
+                dropout=attn_dropout,
+            ),
+        )
+        get_latent_ff = lambda: PreNorm(
+            latent_dim, FeedForward(latent_dim, dropout=ff_dropout)
+        )
 
-        get_cross_attn, get_cross_ff, get_rev_cross_attn, get_rev_cross_ff, get_input_attn, get_latent_attn, get_latent_ff = map(cache_fn, (get_cross_attn, get_cross_ff, get_rev_cross_attn, get_rev_cross_ff, get_input_attn, get_latent_attn, get_latent_ff))
+        (
+            get_cross_attn,
+            get_cross_ff,
+            get_rev_cross_attn,
+            get_rev_cross_ff,
+            get_input_attn,
+            get_latent_attn,
+            get_latent_ff,
+        ) = map(
+            cache_fn,
+            (
+                get_cross_attn,
+                get_cross_ff,
+                get_rev_cross_attn,
+                get_rev_cross_ff,
+                get_input_attn,
+                get_latent_attn,
+                get_latent_ff,
+            ),
+        )
 
         self.layers = nn.ModuleList([])
         for i in range(depth):
             should_cache = i > 0 and weight_tie_layers
-            cache_args = {'_cache': should_cache}
+            cache_args = {"_cache": should_cache}
 
-            self.layers.append(nn.ModuleList([
-                get_cross_attn(**cache_args),
-                get_cross_ff(**cache_args),
-                get_rev_cross_attn(**cache_args),
-                get_rev_cross_ff(**cache_args),
-                get_input_attn(**cache_args),
-                get_latent_attn(**cache_args),
-                get_latent_ff(**cache_args)
-            ]))
+            self.layers.append(
+                nn.ModuleList(
+                    [
+                        get_cross_attn(**cache_args),
+                        get_cross_ff(**cache_args),
+                        get_rev_cross_attn(**cache_args),
+                        get_rev_cross_ff(**cache_args),
+                        get_input_attn(**cache_args),
+                        get_latent_attn(**cache_args),
+                        get_latent_ff(**cache_args),
+                    ]
+                )
+            )
 
         self.to_logits = nn.Sequential(
-            RMSNorm(latent_dim),
-            nn.Linear(latent_dim, num_classes)
+            RMSNorm(latent_dim), nn.Linear(latent_dim, num_classes)
         )
 
-    def forward(self, data, mask = None):
+    def forward(self, data, mask=None):
         b, *axis, _, device = *data.shape, data.device
-        assert len(axis) == self.input_axis, 'input data must have the right number of axis'
+        assert (
+            len(axis) == self.input_axis
+        ), "input data must have the right number of axis"
 
         # calculate fourier encoded positions in the range of [-1, 1], for all axis
 
-        axis_pos = list(map(lambda size: torch.linspace(-1., 1., steps = size, device = device), axis))
-        pos = torch.stack(torch.meshgrid(*axis_pos), dim = -1)
-        enc_pos = fourier_encode(pos, self.max_freq, self.num_freq_bands, base = self.freq_base)
-        enc_pos = rearrange(enc_pos, '... n d -> ... (n d)')
-        enc_pos = repeat(enc_pos, '... -> b ...', b = b)
+        axis_pos = list(
+            map(
+                lambda size: torch.linspace(
+                    -1.0, 1.0, steps=size, device=device
+                ),
+                axis,
+            )
+        )
+        pos = torch.stack(torch.meshgrid(*axis_pos), dim=-1)
+        enc_pos = fourier_encode(
+            pos, self.max_freq, self.num_freq_bands, base=self.freq_base
+        )
+        enc_pos = rearrange(enc_pos, "... n d -> ... (n d)")
+        enc_pos = repeat(enc_pos, "... -> b ...", b=b)
 
         # concat to channels of data and flatten axis
 
-        data = torch.cat((data, enc_pos), dim = -1)
-        data = rearrange(data, 'b ... d -> b (...) d')
+        data = torch.cat((data, enc_pos), dim=-1)
+        data = rearrange(data, "b ... d -> b (...) d")
 
         data = self.data_proj(data)
 
-        x = repeat(self.latents, 'n d -> b n d', b = b)
+        x = repeat(self.latents, "n d -> b n d", b=b)
 
-        for i, (cross_attn, cross_ff, rev_cross_attn, rev_cross_ff, input_attn, latent_attn, latent_ff) in enumerate(self.layers):
+        for i, (
+            cross_attn,
+            cross_ff,
+            rev_cross_attn,
+            rev_cross_ff,
+            input_attn,
+            latent_attn,
+            latent_ff,
+        ) in enumerate(self.layers):
             is_last = i == (len(self.layers) - 1)
 
-            x = cross_attn(x, context = data, mask = mask) + x
+            x = cross_attn(x, context=data, mask=mask) + x
             x = cross_ff(x) + x
 
             if not is_last:
-                data = input_attn(data, mask = mask) + data
-                data = rev_cross_attn(data, context = x) + data
+                data = input_attn(data, mask=mask) + data
+                data = rev_cross_attn(data, context=x) + data
                 data = rev_cross_ff(data) + data
 
             x = latent_attn(x) + x
             x = latent_ff(x) + x
 
-        x = x.mean(dim = -2)
+        x = x.mean(dim=-2)
         return self.to_logits(x)

--- a/perceiver_pytorch/gated.py
+++ b/perceiver_pytorch/gated.py
@@ -4,9 +4,18 @@ import torch.nn.functional as F
 
 from einops import rearrange, repeat
 
-from perceiver_pytorch.perceiver_pytorch import exists, default, cache_fn, fourier_encode, PreNorm, FeedForward, Attention
+from perceiver_pytorch.perceiver_pytorch import (
+    exists,
+    default,
+    cache_fn,
+    fourier_encode,
+    PreNorm,
+    FeedForward,
+    Attention,
+)
 
 # helpers
+
 
 class Residual(nn.Module):
     def __init__(self, fn):
@@ -15,6 +24,7 @@ class Residual(nn.Module):
 
     def forward(self, x, **kwargs):
         return x + self.fn(x, **kwargs)
+
 
 class GRUGating(nn.Module):
     def __init__(self, dim, fn):
@@ -28,14 +38,15 @@ class GRUGating(nn.Module):
         y = self.fn(x, **kwargs)
 
         gated_output = self.gru(
-            rearrange(y, '... d -> (...) d'),
-            rearrange(x, '... d -> (...) d')
+            rearrange(y, "... d -> (...) d"), rearrange(x, "... d -> (...) d")
         )
 
-        gated_output = rearrange(gated_output, '(b n) d -> b n d', b = b)
+        gated_output = rearrange(gated_output, "(b n) d -> b n d", b=b)
         return gated_output
 
+
 # main class
+
 
 class Perceiver(nn.Module):
     def __init__(
@@ -44,19 +55,19 @@ class Perceiver(nn.Module):
         num_freq_bands,
         depth,
         max_freq,
-        freq_base = 2,
-        input_channels = 3,
-        input_axis = 2,
-        num_latents = 512,
-        latent_dim = 512,
-        cross_heads = 1,
-        latent_heads = 8,
-        cross_dim_head = 64,
-        latent_dim_head = 64,
-        num_classes = 1000,
-        attn_dropout = 0.,
-        ff_dropout = 0.,
-        weight_tie_layers = False
+        freq_base=2,
+        input_channels=3,
+        input_axis=2,
+        num_latents=512,
+        latent_dim=512,
+        cross_heads=1,
+        latent_heads=8,
+        cross_dim_head=64,
+        latent_dim_head=64,
+        num_classes=1000,
+        attn_dropout=0.0,
+        ff_dropout=0.0,
+        weight_tie_layers=False
     ):
         super().__init__()
         self.input_axis = input_axis
@@ -68,54 +79,99 @@ class Perceiver(nn.Module):
 
         self.latents = nn.Parameter(torch.randn(num_latents, latent_dim))
 
-        get_cross_attn  = lambda: GRUGating(latent_dim, PreNorm(latent_dim, Attention(latent_dim, input_dim, heads = cross_heads, dim_head = cross_dim_head, dropout = attn_dropout), context_dim = input_dim))
-        get_latent_attn = lambda: GRUGating(latent_dim, PreNorm(latent_dim, Attention(latent_dim, heads = latent_heads, dim_head = latent_dim_head, dropout = attn_dropout)))
-        get_cross_ff    = lambda: Residual(PreNorm(latent_dim, FeedForward(latent_dim, dropout = ff_dropout)))
-        get_latent_ff   = lambda: Residual(PreNorm(latent_dim, FeedForward(latent_dim, dropout = ff_dropout)))
+        get_cross_attn = lambda: GRUGating(
+            latent_dim,
+            PreNorm(
+                latent_dim,
+                Attention(
+                    latent_dim,
+                    input_dim,
+                    heads=cross_heads,
+                    dim_head=cross_dim_head,
+                    dropout=attn_dropout,
+                ),
+                context_dim=input_dim,
+            ),
+        )
+        get_latent_attn = lambda: GRUGating(
+            latent_dim,
+            PreNorm(
+                latent_dim,
+                Attention(
+                    latent_dim,
+                    heads=latent_heads,
+                    dim_head=latent_dim_head,
+                    dropout=attn_dropout,
+                ),
+            ),
+        )
+        get_cross_ff = lambda: Residual(
+            PreNorm(latent_dim, FeedForward(latent_dim, dropout=ff_dropout))
+        )
+        get_latent_ff = lambda: Residual(
+            PreNorm(latent_dim, FeedForward(latent_dim, dropout=ff_dropout))
+        )
 
-        get_cross_attn, get_cross_ff, get_latent_attn, get_latent_ff = map(cache_fn, (get_cross_attn, get_cross_ff, get_latent_attn, get_latent_ff))
+        get_cross_attn, get_cross_ff, get_latent_attn, get_latent_ff = map(
+            cache_fn,
+            (get_cross_attn, get_cross_ff, get_latent_attn, get_latent_ff),
+        )
 
         self.layers = nn.ModuleList([])
         for i in range(depth):
             should_cache = i > 0 and weight_tie_layers
-            cache_args = {'_cache': should_cache}
+            cache_args = {"_cache": should_cache}
 
-            self.layers.append(nn.ModuleList([
-                get_cross_attn(**cache_args),
-                get_cross_ff(**cache_args),
-                get_latent_attn(**cache_args),
-                get_latent_ff(**cache_args)
-            ]))
+            self.layers.append(
+                nn.ModuleList(
+                    [
+                        get_cross_attn(**cache_args),
+                        get_cross_ff(**cache_args),
+                        get_latent_attn(**cache_args),
+                        get_latent_ff(**cache_args),
+                    ]
+                )
+            )
 
         self.to_logits = nn.Sequential(
-            nn.LayerNorm(latent_dim),
-            nn.Linear(latent_dim, num_classes)
+            nn.LayerNorm(latent_dim), nn.Linear(latent_dim, num_classes)
         )
 
-    def forward(self, data, mask = None):
+    def forward(self, data, mask=None):
         b, *axis, _, device = *data.shape, data.device
-        assert len(axis) == self.input_axis, 'input data must have the right number of axis'
+        assert (
+            len(axis) == self.input_axis
+        ), "input data must have the right number of axis"
 
         # calculate fourier encoded positions in the range of [-1, 1], for all axis
 
-        axis_pos = list(map(lambda size: torch.linspace(-1., 1., steps = size, device = device), axis))
-        pos = torch.stack(torch.meshgrid(*axis_pos), dim = -1)
-        enc_pos = fourier_encode(pos, self.max_freq, self.num_freq_bands, base = self.freq_base)
-        enc_pos = rearrange(enc_pos, '... n d -> ... (n d)')
-        enc_pos = repeat(enc_pos, '... -> b ...', b = b)
+        axis_pos = list(
+            map(
+                lambda size: torch.linspace(
+                    -1.0, 1.0, steps=size, device=device
+                ),
+                axis,
+            )
+        )
+        pos = torch.stack(torch.meshgrid(*axis_pos), dim=-1)
+        enc_pos = fourier_encode(
+            pos, self.max_freq, self.num_freq_bands, base=self.freq_base
+        )
+        enc_pos = rearrange(enc_pos, "... n d -> ... (n d)")
+        enc_pos = repeat(enc_pos, "... -> b ...", b=b)
 
         # concat to channels of data and flatten axis
 
-        data = torch.cat((data, enc_pos), dim = -1)
-        data = rearrange(data, 'b ... d -> b (...) d')
+        data = torch.cat((data, enc_pos), dim=-1)
+        data = rearrange(data, "b ... d -> b (...) d")
 
-        x = repeat(self.latents, 'n d -> b n d', b = b)
+        x = repeat(self.latents, "n d -> b n d", b=b)
 
         for cross_attn, cross_ff, latent_attn, latent_ff in self.layers:
-            x = cross_attn(x, context = data, mask = mask)
+            x = cross_attn(x, context=data, mask=mask)
             x = cross_ff(x)
             x = latent_attn(x)
             x = latent_ff(x)
 
-        x = x.mean(dim = -2)
+        x = x.mean(dim=-2)
         return self.to_logits(x)

--- a/perceiver_pytorch/mixed_latents.py
+++ b/perceiver_pytorch/mixed_latents.py
@@ -4,19 +4,30 @@ import torch.nn.functional as F
 
 from einops import rearrange, repeat
 
-from perceiver_pytorch.perceiver_pytorch import exists, default, cache_fn, fourier_encode, PreNorm, FeedForward, Attention
+from perceiver_pytorch.perceiver_pytorch import (
+    exists,
+    default,
+    cache_fn,
+    fourier_encode,
+    PreNorm,
+    FeedForward,
+    Attention,
+)
 
 # latent mixer
 
-def Mixer(seq_len, mult = 4, dropout = 0.):
+
+def Mixer(seq_len, mult=4, dropout=0.0):
     return nn.Sequential(
         nn.Conv1d(seq_len, seq_len * mult, 1),
         nn.GELU(),
         nn.Dropout(dropout),
-        nn.Conv1d(seq_len * mult, seq_len, 1)
+        nn.Conv1d(seq_len * mult, seq_len, 1),
     )
 
+
 # main class
+
 
 class Perceiver(nn.Module):
     def __init__(
@@ -25,19 +36,19 @@ class Perceiver(nn.Module):
         num_freq_bands,
         depth,
         max_freq,
-        freq_base = 2,
-        input_channels = 3,
-        input_axis = 2,
-        num_latents = 512,
-        latent_dim = 512,
-        cross_heads = 1,
-        latent_heads = 8,
-        cross_dim_head = 64,
-        latent_dim_head = 64,
-        num_classes = 1000,
-        attn_dropout = 0.,
-        ff_dropout = 0.,
-        weight_tie_layers = False,
+        freq_base=2,
+        input_channels=3,
+        input_axis=2,
+        num_latents=512,
+        latent_dim=512,
+        cross_heads=1,
+        latent_heads=8,
+        cross_dim_head=64,
+        latent_dim_head=64,
+        num_classes=1000,
+        attn_dropout=0.0,
+        ff_dropout=0.0,
+        weight_tie_layers=False,
         **kwargs
     ):
         super().__init__()
@@ -50,54 +61,87 @@ class Perceiver(nn.Module):
 
         self.latents = nn.Parameter(torch.randn(num_latents, latent_dim))
 
-        get_cross_attn  = lambda: PreNorm(latent_dim, Attention(latent_dim, input_dim, heads = cross_heads, dim_head = cross_dim_head, dropout = attn_dropout), context_dim = input_dim)
-        get_latent_attn = lambda: PreNorm(latent_dim, Mixer(num_latents, dropout = ff_dropout))
-        get_cross_ff    = lambda: PreNorm(latent_dim, FeedForward(latent_dim, dropout = ff_dropout))
-        get_latent_ff   = lambda: PreNorm(latent_dim, FeedForward(latent_dim, dropout = ff_dropout))
+        get_cross_attn = lambda: PreNorm(
+            latent_dim,
+            Attention(
+                latent_dim,
+                input_dim,
+                heads=cross_heads,
+                dim_head=cross_dim_head,
+                dropout=attn_dropout,
+            ),
+            context_dim=input_dim,
+        )
+        get_latent_attn = lambda: PreNorm(
+            latent_dim, Mixer(num_latents, dropout=ff_dropout)
+        )
+        get_cross_ff = lambda: PreNorm(
+            latent_dim, FeedForward(latent_dim, dropout=ff_dropout)
+        )
+        get_latent_ff = lambda: PreNorm(
+            latent_dim, FeedForward(latent_dim, dropout=ff_dropout)
+        )
 
-        get_cross_attn, get_cross_ff, get_latent_attn, get_latent_ff = map(cache_fn, (get_cross_attn, get_cross_ff, get_latent_attn, get_latent_ff))
+        get_cross_attn, get_cross_ff, get_latent_attn, get_latent_ff = map(
+            cache_fn,
+            (get_cross_attn, get_cross_ff, get_latent_attn, get_latent_ff),
+        )
 
         self.layers = nn.ModuleList([])
         for i in range(depth):
             should_cache = i > 0 and weight_tie_layers
-            cache_args = {'_cache': should_cache}
+            cache_args = {"_cache": should_cache}
 
-            self.layers.append(nn.ModuleList([
-                get_cross_attn(**cache_args),
-                get_cross_ff(**cache_args),
-                get_latent_attn(**cache_args),
-                get_latent_ff(**cache_args)
-            ]))
+            self.layers.append(
+                nn.ModuleList(
+                    [
+                        get_cross_attn(**cache_args),
+                        get_cross_ff(**cache_args),
+                        get_latent_attn(**cache_args),
+                        get_latent_ff(**cache_args),
+                    ]
+                )
+            )
 
         self.to_logits = nn.Sequential(
-            nn.LayerNorm(latent_dim),
-            nn.Linear(latent_dim, num_classes)
+            nn.LayerNorm(latent_dim), nn.Linear(latent_dim, num_classes)
         )
 
-    def forward(self, data, mask = None):
+    def forward(self, data, mask=None):
         b, *axis, _, device = *data.shape, data.device
-        assert len(axis) == self.input_axis, 'input data must have the right number of axis'
+        assert (
+            len(axis) == self.input_axis
+        ), "input data must have the right number of axis"
 
         # calculate fourier encoded positions in the range of [-1, 1], for all axis
 
-        axis_pos = list(map(lambda size: torch.linspace(-1., 1., steps = size, device = device), axis))
-        pos = torch.stack(torch.meshgrid(*axis_pos), dim = -1)
-        enc_pos = fourier_encode(pos, self.max_freq, self.num_freq_bands, base = self.freq_base)
-        enc_pos = rearrange(enc_pos, '... n d -> ... (n d)')
-        enc_pos = repeat(enc_pos, '... -> b ...', b = b)
+        axis_pos = list(
+            map(
+                lambda size: torch.linspace(
+                    -1.0, 1.0, steps=size, device=device
+                ),
+                axis,
+            )
+        )
+        pos = torch.stack(torch.meshgrid(*axis_pos), dim=-1)
+        enc_pos = fourier_encode(
+            pos, self.max_freq, self.num_freq_bands, base=self.freq_base
+        )
+        enc_pos = rearrange(enc_pos, "... n d -> ... (n d)")
+        enc_pos = repeat(enc_pos, "... -> b ...", b=b)
 
         # concat to channels of data and flatten axis
 
-        data = torch.cat((data, enc_pos), dim = -1)
-        data = rearrange(data, 'b ... d -> b (...) d')
+        data = torch.cat((data, enc_pos), dim=-1)
+        data = rearrange(data, "b ... d -> b (...) d")
 
-        x = repeat(self.latents, 'n d -> b n d', b = b)
+        x = repeat(self.latents, "n d -> b n d", b=b)
 
         for cross_attn, cross_ff, latent_attn, latent_ff in self.layers:
-            x = cross_attn(x, context = data, mask = mask) + x
+            x = cross_attn(x, context=data, mask=mask) + x
             x = cross_ff(x) + x
             x = latent_attn(x) + x
             x = latent_ff(x) + x
 
-        x = x.mean(dim = -2)
+        x = x.mean(dim=-2)
         return self.to_logits(x)

--- a/perceiver_pytorch/multi_perceiver_pytorch.py
+++ b/perceiver_pytorch/multi_perceiver_pytorch.py
@@ -1,0 +1,166 @@
+from perceiver_pytorch.perceiver_pytorch import PerceiverIO, fourier_encode
+import torch
+from typing import List, Iterable, Dict, Optional, Any
+from einops import rearrange, repeat
+from dataclasses import dataclass
+
+
+@dataclass
+class InputModality:
+    name: str
+    input_channels: int
+    input_axis: int
+    num_freq_bands: int
+    max_freq: float
+    freq_base: int = 2
+    sin_only: bool = False
+    fourier_encode: bool = True
+
+    @property
+    def input_dim(self) -> int:
+        # Calculate the dimension of this modality.
+        fourier_channels = self.input_axis * ((self.num_freq_bands * 2) + 1)
+        fourier_channels = fourier_channels // 2 if self.sin_only else fourier_channels
+        input_dim = fourier_channels + self.input_channels
+        return input_dim
+
+
+def modality_encoding(batch_size: int, axes, modality_index: int, num_modalities: int) -> torch.Tensor:
+    """
+    Return one-hot encoding of modality given num_modalities, batch size and axes.
+    The result need to be compatible with the modality data for concatenation.
+    :param modality_index:
+    :param num_modalities:
+    :return:
+    """
+    one_hot = torch.eye(num_modalities, num_modalities)[modality_index]
+    to_expand = [batch_size]
+    one_hot = one_hot.unsqueeze(0)
+    for i, axis in enumerate(axes):
+        one_hot = one_hot.unsqueeze(0)
+        to_expand.append(axis)
+    to_expand.append(num_modalities)
+
+    one_hot = one_hot.expand(to_expand)
+    return one_hot
+
+
+class MultiPerceiver(torch.nn.Module):
+    def __init__(
+            self,
+            modalities: Iterable[InputModality],
+            fourier_encode_data: bool = True,
+            input_channels: int = 3,
+            output_channels: int = 12,
+            forecast_steps: int = 48,
+            sin_only: bool = False,
+            output_shape: int = 32,
+            **kwargs,
+    ):
+        """
+        PerceiverIO made to work more specifically with timeseries images
+        Not a recurrent model, so like MetNet somewhat, can optionally give a one-hot encoded vector for the future
+        timestep
+        Args:
+            input_channels: Number of input channels
+            forecast_steps: Number of forecast steps to make
+            **kwargs:
+        """
+        super(MultiPerceiver, self).__init__()
+        self.fourier_encode_data = fourier_encode_data
+        self.forecast_steps = forecast_steps
+        self.input_channels = input_channels
+        self.sin_only = sin_only
+        self.output_channels = output_channels
+        self.modalities = {modality.name: modality for modality in modalities}
+        # we encode modality with one hot encoding, so need one dim per modality:
+        modality_encoding_dim = sum([1 for _ in modalities])
+        # input_dim is the maximum dimension over all input modalities:
+        input_dim = max(modality.input_dim for modality in modalities) + modality_encoding_dim
+        # Pop dim
+        self.max_modality_dim = input_dim
+        kwargs.pop("dim")
+        # Want toe logit_dim to be the same as the channels * width or height
+        kwargs["logits_dim"] = output_shape * self.output_channels
+        self.perceiver = PerceiverIO(dim=input_dim, **kwargs)
+
+    def decode_output(self, data):
+        pass
+
+    def forward(self, multi_modality_data: Dict[str, torch.Tensor], mask=None, queries=None):
+        batch_sizes = set()
+        num_modalities = len(multi_modality_data)
+        linearized_data = []
+
+        for modality_index, modality_name in enumerate(sorted(multi_modality_data.keys())):
+            assert (
+                    modality_name in self.modalities
+            ), f"modality {modality_name} was not defined in constructor"
+            data = multi_modality_data[modality_name]
+            modality = self.modalities[modality_name]
+            b, *axis, _ = data.size()
+            assert len(axis) == modality.input_axis, (
+                f"input data must have the right number of  for modality {modality_name}. "
+                f"Expected {modality.input_axis} while forward argument offered {len(axis)}"
+            )
+            batch_sizes.add(b)
+            assert len(batch_sizes) == 1, "batch size must be the same across all modalities"
+            enc_pos = []
+            if self.fourier_encode_data:
+                # calculate fourier encoded positions in the range of [-1, 1], for all axis
+
+                axis_pos = list(
+                    map(lambda size: torch.linspace(-1.0, 1.0, steps=size).type_as(data), axis)
+                )
+                pos = torch.stack(torch.meshgrid(*axis_pos), dim=-1)
+                enc_pos = fourier_encode(
+                    pos,
+                    modality.max_freq,
+                    modality.num_freq_bands,
+                    modality.freq_base,
+                    sin_only=self.sin_only,
+                )
+                enc_pos = rearrange(enc_pos, "... n d -> ... (n d)")
+                enc_pos = repeat(enc_pos, "... -> b ...", b=b)
+
+            # Figure out padding for this modality, given max dimension across all modalities:
+            padding_size = self.max_modality_dim - modality.input_dim - num_modalities
+
+            padding = torch.zeros(size=data.size()[0:-1] + (padding_size,)).type_as(data)
+            # concat to channels of data and flatten axis
+            modality_encodings = modality_encoding(
+                b, axis, modality_index, num_modalities
+            ).type_as(data)
+            to_concat = (
+                (data, padding, enc_pos, modality_encodings)
+                if len(enc_pos) > 0
+                else (data, padding, modality_encodings)
+            )
+            data = torch.cat(to_concat, dim=-1)
+            # concat to channels of data and flatten axis
+            data = rearrange(data, "b ... d -> b (...) d")
+            linearized_data.append(data)
+
+        # Concatenate all the modalities:
+        data = torch.cat(linearized_data, dim=1)
+
+        # After this is the PerceiverIO backbone, still would need to decode it back to an image though
+        # Should include the query shape here for the output we want, could be learned embeddings, repeated input frames of the same shape that is desired, etc.
+        perceiver_output = self.perceiver.forward(data, mask, queries)
+
+        # For multiple modalities, they are split after this beack into different tensors
+        # For Sat images, we just want the images, not the other ones, so can leave it as is?
+
+        # Have to decode back into future Sat image frames
+        # Perceiver for 'pixel' postprocessing does nothing, or undoes the space2depth from before if just image
+        # If doing depth2space, should split modalities again
+
+        # Reshape to the correct output
+        # This is how it is done in the official implementation, do a decoder query with cross attention, then just reshape the output
+        # For timeseries, this is given as a query with T*H*W shape
+        # For Flow Decoder, this is the same, except has a rescale factor
+        perceiver_output = rearrange(
+            perceiver_output, "b h (w c) -> b c h w", c=self.output_channels
+        )
+
+        return perceiver_output

--- a/perceiver_pytorch/perceiver_pytorch.py
+++ b/perceiver_pytorch/perceiver_pytorch.py
@@ -149,6 +149,34 @@ class Perceiver(nn.Module):
         self_per_cross_attn = 1,
         self_attn_rel_pos = True
     ):
+        """The shape of the final attention mechanism will be:
+        depth * (cross attention -> self_per_cross_attn * self attention)
+
+        Args:
+          num_freq_bands: Number of freq bands, with original value (2 * K + 1)
+          depth: Depth of net.
+          max_freq: Maximum frequency, hyperparameter depending on how
+              fine the data is.
+          freq_base:
+          input_channels: Number of channels for each token of the input.
+          input_axis: Number of axes for input data (2 for images, 3 for video)
+          num_latents: Number of latents, or induced set points, or centroids.
+              Different papers giving it different names.
+          latent_dim: Latent dimension.
+          cross_heads: Number of heads for cross attention. Paper said 1.
+          latent_heads: Number of heads for latent self attention, 8.
+          cross_dim_head: Number of dimensions per cross attention head.
+          latent_dim_head: Number of dimensions per latent self attention head.
+          num_classes: Output number of classes.
+          attn_dropout:
+          ff_dropout:
+          weight_tie_layers: Whether to weight tie layers (optional).
+          fourier_encode_data: Whether to auto-fourier encode the data, using
+              the input_axis given. defaults to True, but can be turned off
+              if you are fourier encoding the data yourself.
+          self_per_cross_attn: Number of self attention blocks per cross attn.
+          self_attn_rel_pos:
+        """
         super().__init__()
         self.input_axis = input_axis
         self.max_freq = max_freq

--- a/perceiver_pytorch/perceiver_pytorch.py
+++ b/perceiver_pytorch/perceiver_pytorch.py
@@ -11,16 +11,20 @@ from perceiver_pytorch.rotary import SinusoidalEmbeddings, apply_rotary_emb
 
 # helpers
 
+
 def exists(val):
     return val is not None
+
 
 def default(val, d):
     return val if exists(val) else d
 
+
 def cache_fn(f):
     cache = None
+
     @wraps(f)
-    def cached_fn(*args, _cache = True, **kwargs):
+    def cached_fn(*args, _cache=True, **kwargs):
         if not _cache:
             return f(*args, **kwargs)
         nonlocal cache
@@ -28,59 +32,77 @@ def cache_fn(f):
             return cache
         cache = f(*args, **kwargs)
         return cache
+
     return cached_fn
 
-def fourier_encode(x, max_freq, num_bands = 4, base = 2):
+
+def fourier_encode(x, max_freq, num_bands=4, base=2):
     x = x.unsqueeze(-1)
     device, dtype, orig_x = x.device, x.dtype, x
 
-    scales = torch.logspace(0., log(max_freq / 2) / log(base), num_bands, base = base, device = device, dtype = dtype)
+    scales = torch.logspace(
+        0.0,
+        log(max_freq / 2) / log(base),
+        num_bands,
+        base=base,
+        device=device,
+        dtype=dtype,
+    )
     scales = scales[(*((None,) * (len(x.shape) - 1)), Ellipsis)]
 
     x = x * scales * pi
     x = torch.cat([x.sin(), x.cos()], dim=-1)
-    x = torch.cat((x, orig_x), dim = -1)
+    x = torch.cat((x, orig_x), dim=-1)
     return x
+
 
 # helper classes
 
+
 class PreNorm(nn.Module):
-    def __init__(self, dim, fn, context_dim = None):
+    def __init__(self, dim, fn, context_dim=None):
         super().__init__()
         self.fn = fn
         self.norm = nn.LayerNorm(dim)
-        self.norm_context = nn.LayerNorm(context_dim) if exists(context_dim) else None
+        self.norm_context = (
+            nn.LayerNorm(context_dim) if exists(context_dim) else None
+        )
 
     def forward(self, x, **kwargs):
         x = self.norm(x)
 
         if exists(self.norm_context):
-            context = kwargs['context']
+            context = kwargs["context"]
             normed_context = self.norm_context(context)
-            kwargs.update(context = normed_context)
+            kwargs.update(context=normed_context)
 
         return self.fn(x, **kwargs)
 
+
 class GEGLU(nn.Module):
     def forward(self, x):
-        x, gates = x.chunk(2, dim = -1)
+        x, gates = x.chunk(2, dim=-1)
         return x * F.gelu(gates)
 
+
 class FeedForward(nn.Module):
-    def __init__(self, dim, mult = 4, dropout = 0.):
+    def __init__(self, dim, mult=4, dropout=0.0):
         super().__init__()
         self.net = nn.Sequential(
             nn.Linear(dim, dim * mult * 2),
             GEGLU(),
             nn.Dropout(dropout),
-            nn.Linear(dim * mult, dim)
+            nn.Linear(dim * mult, dim),
         )
 
     def forward(self, x):
         return self.net(x)
 
+
 class Attention(nn.Module):
-    def __init__(self, query_dim, context_dim = None, heads = 8, dim_head = 64, dropout = 0.):
+    def __init__(
+        self, query_dim, context_dim=None, heads=8, dim_head=64, dropout=0.0
+    ):
         super().__init__()
         inner_dim = dim_head * heads
         context_dim = default(context_dim, query_dim)
@@ -88,42 +110,45 @@ class Attention(nn.Module):
         self.scale = dim_head ** -0.5
         self.heads = heads
 
-        self.to_q = nn.Linear(query_dim, inner_dim, bias = False)
-        self.to_kv = nn.Linear(context_dim, inner_dim * 2, bias = False)
+        self.to_q = nn.Linear(query_dim, inner_dim, bias=False)
+        self.to_kv = nn.Linear(context_dim, inner_dim * 2, bias=False)
 
         self.to_out = nn.Sequential(
-            nn.Linear(inner_dim, query_dim),
-            nn.Dropout(dropout)
+            nn.Linear(inner_dim, query_dim), nn.Dropout(dropout)
         )
 
-    def forward(self, x, context = None, mask = None, pos_emb = None):
+    def forward(self, x, context=None, mask=None, pos_emb=None):
         h = self.heads
 
         q = self.to_q(x)
         context = default(context, x)
-        k, v = self.to_kv(context).chunk(2, dim = -1)
+        k, v = self.to_kv(context).chunk(2, dim=-1)
 
-        q, k, v = map(lambda t: rearrange(t, 'b n (h d) -> (b h) n d', h = h), (q, k, v))
+        q, k, v = map(
+            lambda t: rearrange(t, "b n (h d) -> (b h) n d", h=h), (q, k, v)
+        )
 
         if exists(pos_emb):
             q, k = apply_rotary_emb(q, k, pos_emb)
 
-        sim = einsum('b i d, b j d -> b i j', q, k) * self.scale
+        sim = einsum("b i d, b j d -> b i j", q, k) * self.scale
 
         if exists(mask):
-            mask = rearrange(mask, 'b ... -> b (...)')
+            mask = rearrange(mask, "b ... -> b (...)")
             max_neg_value = -torch.finfo(sim.dtype).max
-            mask = repeat(mask, 'b j -> (b h) () j', h = h)
+            mask = repeat(mask, "b j -> (b h) () j", h=h)
             sim.masked_fill_(~mask, max_neg_value)
 
         # attention, what we cannot get enough of
-        attn = sim.softmax(dim = -1)
+        attn = sim.softmax(dim=-1)
 
-        out = einsum('b i j, b j d -> b i d', attn, v)
-        out = rearrange(out, '(b h) n d -> b n (h d)', h = h)
+        out = einsum("b i j, b j d -> b i d", attn, v)
+        out = rearrange(out, "(b h) n d -> b n (h d)", h=h)
         return self.to_out(out)
 
+
 # main class
+
 
 class Perceiver(nn.Module):
     def __init__(
@@ -132,22 +157,22 @@ class Perceiver(nn.Module):
         num_freq_bands,
         depth,
         max_freq,
-        freq_base = 2,
-        input_channels = 3,
-        input_axis = 2,
-        num_latents = 512,
-        latent_dim = 512,
-        cross_heads = 1,
-        latent_heads = 8,
-        cross_dim_head = 64,
-        latent_dim_head = 64,
-        num_classes = 1000,
-        attn_dropout = 0.,
-        ff_dropout = 0.,
-        weight_tie_layers = False,
-        fourier_encode_data = True,
-        self_per_cross_attn = 1,
-        self_attn_rel_pos = True
+        freq_base=2,
+        input_channels=3,
+        input_axis=2,
+        num_latents=512,
+        latent_dim=512,
+        cross_heads=1,
+        latent_heads=8,
+        cross_dim_head=64,
+        latent_dim_head=64,
+        num_classes=1000,
+        attn_dropout=0.0,
+        ff_dropout=0.0,
+        weight_tie_layers=False,
+        fourier_encode_data=True,
+        self_per_cross_attn=1,
+        self_attn_rel_pos=True
     ):
         """The shape of the final attention mechanism will be:
         depth * (cross attention -> self_per_cross_attn * self attention)
@@ -184,80 +209,127 @@ class Perceiver(nn.Module):
         self.freq_base = freq_base
 
         self.fourier_encode_data = fourier_encode_data
-        fourier_channels = (input_axis * ((num_freq_bands * 2) + 1)) if fourier_encode_data else 0
+        fourier_channels = (
+            (input_axis * ((num_freq_bands * 2) + 1))
+            if fourier_encode_data
+            else 0
+        )
         input_dim = fourier_channels + input_channels
 
         self.latents = nn.Parameter(torch.randn(num_latents, latent_dim))
 
-        get_cross_attn = lambda: PreNorm(latent_dim, Attention(latent_dim, input_dim, heads = cross_heads, dim_head = cross_dim_head, dropout = attn_dropout), context_dim = input_dim)
-        get_cross_ff = lambda: PreNorm(latent_dim, FeedForward(latent_dim, dropout = ff_dropout))
-        get_latent_attn = lambda: PreNorm(latent_dim, Attention(latent_dim, heads = latent_heads, dim_head = latent_dim_head, dropout = attn_dropout))
-        get_latent_ff = lambda: PreNorm(latent_dim, FeedForward(latent_dim, dropout = ff_dropout))
+        def get_cross_attn():
+            return PreNorm(
+                latent_dim,
+                Attention(
+                    latent_dim,
+                    input_dim,
+                    heads=cross_heads,
+                    dim_head=cross_dim_head,
+                    dropout=attn_dropout,
+                ),
+                context_dim=input_dim)
 
-        get_cross_attn, get_cross_ff, get_latent_attn, get_latent_ff = map(cache_fn, (get_cross_attn, get_cross_ff, get_latent_attn, get_latent_ff))
+        def get_cross_ff():
+            return PreNorm(
+                latent_dim,
+                FeedForward(latent_dim, dropout=ff_dropout))
+
+        def get_latent_attn():
+            return PreNorm(
+                latent_dim,
+                Attention(
+                    latent_dim,
+                    heads=latent_heads,
+                    dim_head=latent_dim_head,
+                    dropout=attn_dropout,
+                ))
+
+        def get_latent_ff():
+            return PreNorm(
+                latent_dim,
+                FeedForward(latent_dim, dropout=ff_dropout))
+
+        # Cache all the above functions.
+        get_cross_attn, get_cross_ff, get_latent_attn, get_latent_ff = map(
+            cache_fn,
+            (get_cross_attn, get_cross_ff, get_latent_attn, get_latent_ff))
 
         self.layers = nn.ModuleList([])
         for i in range(depth):
             should_cache = i > 0 and weight_tie_layers
-            cache_args = {'_cache': should_cache}
+            cache_args = {"_cache": should_cache}
 
             self_attns = nn.ModuleList([])
 
             for _ in range(self_per_cross_attn):
-                self_attns.append(nn.ModuleList([
-                    get_latent_attn(**cache_args),
-                    get_latent_ff(**cache_args)
-                ]))
+                self_attns.append(
+                    nn.ModuleList(
+                        [
+                            get_latent_attn(**cache_args),
+                            get_latent_ff(**cache_args),
+                        ]
+                    ))
 
-            self.layers.append(nn.ModuleList([
-                get_cross_attn(**cache_args),
-                get_cross_ff(**cache_args),
-                self_attns
-            ]))
+            self.layers.append(
+                nn.ModuleList(
+                    [
+                        get_cross_attn(**cache_args),
+                        get_cross_ff(**cache_args),
+                        self_attns,
+                    ]
+                ))
 
         self.to_logits = nn.Sequential(
             nn.LayerNorm(latent_dim),
-            nn.Linear(latent_dim, num_classes)
-        )
+            nn.Linear(latent_dim, num_classes))
 
         self.sinu_emb = None
         if self_attn_rel_pos:
             self.sinu_emb = SinusoidalEmbeddings(latent_dim_head)
 
-    def forward(self, data, mask = None):
-        b, *axis, _, device = *data.shape, data.device
-        assert len(axis) == self.input_axis, 'input data must have the right number of axis'
+    def forward(self, data, mask=None):
+        b, *axis, _ = *data.shape
+        device = data.device
+        assert (
+            len(axis) == self.input_axis
+        ), f"Input data must have {self.input_axis} axes, not {len(axis)}!"
 
         if self.fourier_encode_data:
-            # calculate fourier encoded positions in the range of [-1, 1], for all axis
+            # Calculate Fourier encoded positions in the range of [-1, 1],
+            # for all axes.
+            axis_pos = list(
+                map(
+                    lambda size:
+                    torch.linspace(
+                        -1.0, 1.0, steps=size, device=device
+                    ),
+                    axis))
+            pos = torch.stack(torch.meshgrid(*axis_pos), dim=-1)
+            enc_pos = fourier_encode(
+                pos, self.max_freq, self.num_freq_bands, base=self.freq_base)
+            enc_pos = rearrange(enc_pos, "... n d -> ... (n d)")
+            enc_pos = repeat(enc_pos, "... -> b ...", b=b)
 
-            axis_pos = list(map(lambda size: torch.linspace(-1., 1., steps = size, device = device), axis))
-            pos = torch.stack(torch.meshgrid(*axis_pos), dim = -1)
-            enc_pos = fourier_encode(pos, self.max_freq, self.num_freq_bands, base = self.freq_base)
-            enc_pos = rearrange(enc_pos, '... n d -> ... (n d)')
-            enc_pos = repeat(enc_pos, '... -> b ...', b = b)
+            data = torch.cat((data, enc_pos), dim=-1)
 
-            data = torch.cat((data, enc_pos), dim = -1)
+        # Concat to channels of data and flatten axis.
+        data = rearrange(data, "b ... d -> b (...) d")
 
-        # concat to channels of data and flatten axis
+        # x is the 'latent array' in the paper.
+        x = repeat(self.latents, "n d -> b n d", b=b)
 
-        data = rearrange(data, 'b ... d -> b (...) d')
-
-        x = repeat(self.latents, 'n d -> b n d', b = b)
-
-        # rotary embeddings for latents, if specified
-
+        # Rotary embeddings for latents, if specified.
         pos_emb = self.sinu_emb(x) if exists(self.sinu_emb) else None
 
-        # layers
-
+        # Layers.
         for cross_attn, cross_ff, self_attns in self.layers:
-            x = cross_attn(x, context = data, mask = mask) + x
+            x = cross_attn(x, context=data, mask=mask) + x
             x = cross_ff(x) + x
 
             for self_attn, self_ff in self_attns:
-                x = self_attn(x, pos_emb = pos_emb) + x
+                x = self_attn(x, pos_emb=pos_emb) + x
                 x = self_ff(x) + x
 
-        x = x.mean(dim = -2)
+        x = x.mean(dim=-2)
         return self.to_logits(x)

--- a/perceiver_pytorch/rotary.py
+++ b/perceiver_pytorch/rotary.py
@@ -2,28 +2,31 @@ import torch
 from torch import nn, einsum
 from einops import rearrange, repeat
 
+
 class SinusoidalEmbeddings(nn.Module):
     def __init__(self, dim):
         super().__init__()
-        inv_freq = 1. / (10000 ** (torch.arange(0, dim, 2).float() / dim))
-        self.register_buffer('inv_freq', inv_freq)
+        inv_freq = 1.0 / (10000 ** (torch.arange(0, dim, 2).float() / dim))
+        self.register_buffer("inv_freq", inv_freq)
 
     def forward(self, x):
         n = x.shape[-2]
-        t = torch.arange(n, device = x.device).type_as(self.inv_freq)
-        sinusoid_inp = torch.einsum('i , j -> i j', t, self.inv_freq)
+        t = torch.arange(n, device=x.device).type_as(self.inv_freq)
+        sinusoid_inp = torch.einsum("i , j -> i j", t, self.inv_freq)
         emb = torch.cat((sinusoid_inp.sin(), sinusoid_inp.cos()), dim=-1)
         return emb[None, :, :]
 
+
 def rotate_every_two(x):
-    x = rearrange(x, '... (d j) -> ... d j', j = 2)
-    x1, x2 = x.unbind(dim = -1)
-    x = torch.stack((-x2, x1), dim = -1)
-    return rearrange(x, '... d j -> ... (d j)')
+    x = rearrange(x, "... (d j) -> ... d j", j=2)
+    x1, x2 = x.unbind(dim=-1)
+    x = torch.stack((-x2, x1), dim=-1)
+    return rearrange(x, "... d j -> ... (d j)")
+
 
 def apply_rotary_emb(q, k, sinu_pos):
-    sinu_pos = rearrange(sinu_pos, '() n (j d) -> n j d', j = 2)
-    sin, cos = sinu_pos.unbind(dim = -2)
-    sin, cos = map(lambda t: repeat(t, 'b n -> b (n j)', j = 2), (sin, cos))
+    sinu_pos = rearrange(sinu_pos, "() n (j d) -> n j d", j=2)
+    sin, cos = sinu_pos.unbind(dim=-2)
+    sin, cos = map(lambda t: repeat(t, "b n -> b (n j)", j=2), (sin, cos))
     q, k = map(lambda t: (t * cos) + (rotate_every_two(t) * sin), (q, k))
     return q, k

--- a/setup.py
+++ b/setup.py
@@ -1,29 +1,26 @@
 from setuptools import setup, find_packages
 
 setup(
-  name = 'perceiver-pytorch',
-  packages = find_packages(),
-  version = '0.4.0',
-  license='MIT',
-  description = 'Perceiver - Pytorch',
-  author = 'Phil Wang',
-  author_email = 'lucidrains@gmail.com',
-  url = 'https://github.com/lucidrains/perceiver-pytorch',
-  keywords = [
-    'artificial intelligence',
-    'deep learning',
-    'transformer',
-    'attention mechanism'
-  ],
-  install_requires=[
-    'einops>=0.3',
-    'torch>=1.6'
-  ],
-  classifiers=[
-    'Development Status :: 4 - Beta',
-    'Intended Audience :: Developers',
-    'Topic :: Scientific/Engineering :: Artificial Intelligence',
-    'License :: OSI Approved :: MIT License',
-    'Programming Language :: Python :: 3.6',
-  ],
+    name="perceiver-pytorch",
+    packages=find_packages(),
+    version="0.4.0",
+    license="MIT",
+    description="Perceiver - Pytorch",
+    author="Phil Wang",
+    author_email="lucidrains@gmail.com",
+    url="https://github.com/lucidrains/perceiver-pytorch",
+    keywords=[
+        "artificial intelligence",
+        "deep learning",
+        "transformer",
+        "attention mechanism",
+    ],
+    install_requires=["einops>=0.3", "torch>=1.6"],
+    classifiers=[
+        "Development Status :: 4 - Beta",
+        "Intended Audience :: Developers",
+        "Topic :: Scientific/Engineering :: Artificial Intelligence",
+        "License :: OSI Approved :: MIT License",
+        "Programming Language :: Python :: 3.6",
+    ],
 )


### PR DESCRIPTION
Taken from https://github.com/openclimatefix/satflow/blob/main/satflow/models/perceiver.py 

Allows giving different modalities, which the model then concatenates together. Essentially a wrapper around the PerceiverIO in this repo